### PR TITLE
removed User-Agent headers on HTTP requests to block explorers

### DIFF
--- a/src/chain-explorer.js
+++ b/src/chain-explorer.js
@@ -36,7 +36,6 @@ class ChainExplorer {
       method: 'GET',
       headers: {
         Accept: '*/*',
-        'User-Agent': 'javascript-opentimestamps',
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       json: true,
@@ -67,7 +66,6 @@ class ChainExplorer {
       method: 'GET',
       headers: {
         Accept: 'application/json',
-        'User-Agent': 'javascript-opentimestamps',
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       json: true,


### PR DESCRIPTION
User-Agent headers fail on some browsers (e.g. Firefox) as CORS policy triggers pre-flight request

see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests